### PR TITLE
Chore/change button props type name

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -28,6 +28,7 @@ export default [
         minimize: true
       }),
       babel({
+        babelHelpers: 'bundled',
         exclude: 'node_modules/**',
         presets: ['@babel/preset-react', '@babel/preset-typescript']
       }),
@@ -36,6 +37,16 @@ export default [
       commonjs(),
       typescript({ tsconfig: "./tsconfig.json" }),
     ],
+    onwarn(warning, warn) {
+      // Ignore circular dependency warnings from @internationalized/date
+      if (
+        warning.code === 'CIRCULAR_DEPENDENCY' &&
+        /@internationalized\/date/.test(warning.importer)
+      ) {
+        return
+      }
+      warn(warning)
+    },
   },
   {
     input: "dist/esm/types/index.d.ts",

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -14,19 +14,19 @@ type StyledButtonProps = {
    *
    * @default block
    */
-  buttonType: ButtonType;
+  buttonType?: ButtonType;
   /**
    *  Forces the width to 100% of the parent container.
    *
    * @default false
    */
-  fullWidth: boolean;
+  fullWidth?: boolean;
   /**
    *  Adds padding to the button to create different sizes.
    *
    * @default md
    */
-  size: Size;
+  size?: Size;
 };
 
 const StyledButton = styled("button")<StyledButtonProps>(
@@ -98,7 +98,7 @@ const StyledButton = styled("button")<StyledButtonProps>(
   })
 );
 
-export type ButtonPropsWithAria = {
+export type ButtonProps = {
   /**
    *  Applies an optional preceding icon to the label.
    */
@@ -107,7 +107,7 @@ export type ButtonPropsWithAria = {
   React.ButtonHTMLAttributes<HTMLButtonElement> &
   AriaButtonProps;
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonPropsWithAria>(
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (baseProps, forwardedRef) => {
     const internalRef = React.useRef<HTMLButtonElement | null>(null);
     const ref = useObjectRef(forwardedRef) || internalRef;

--- a/src/components/Modal/stories/ModalContent.stories.tsx
+++ b/src/components/Modal/stories/ModalContent.stories.tsx
@@ -31,7 +31,7 @@ export const Demo: ModalContentStory = {
     children: (
       <>
         <Modal.Header title="Modal" />
-        <Button isFullWidth>Button</Button>
+        <Button fullWidth>Button</Button>
       </>
     ),
   },


### PR DESCRIPTION
### Work that was done

**Button**
Made the StyledButton props optional (except for `children`). Also changed the props time name back to ButtonProps.

**Modal**
There was a story that had a button that was using `isFullWidth` as a prop, so changed it to `fullWidth`.
