### PR TITLE
fix(Dropdown): added z-index to flyout and type prop to button

### DIFF
--- a/src/components/Dropdown/DropdownFlyout.tsx
+++ b/src/components/Dropdown/DropdownFlyout.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
-import styled from '@emotion/styled'
-import { css, keyframes } from '@emotion/react'
-import { defaultTheme } from '../emotionTheme'
+import React from "react"
+import styled from "@emotion/styled"
+import { css, keyframes } from "@emotion/react"
+import { defaultTheme } from "../emotionTheme"
 
 const slideIn = keyframes`
   from {
@@ -31,18 +31,19 @@ type DropdownFlyoutContainerProps = {
   flyoutMaxHeight?: string
 }
 
-const DropdownFlyoutContainer = styled('div')<DropdownFlyoutContainerProps>(
+const DropdownFlyoutContainer = styled("div")<DropdownFlyoutContainerProps>(
   {
-    position: 'absolute',
+    position: "absolute",
     top: 76,
     left: 0,
     right: 0,
-    overflowY: 'scroll',
+    overflowY: "scroll",
     opacity: 0,
-    transition: 'transform 0.3s ease-out, opacity 0.3s ease-out',
+    transition: "transform 0.3s ease-out, opacity 0.3s ease-out",
+    zIndex: 100,
   },
   ({ flyoutMaxHeight }) => ({
-    maxHeight: flyoutMaxHeight ? flyoutMaxHeight : 'initial',
+    maxHeight: flyoutMaxHeight ? flyoutMaxHeight : "initial",
   }),
   ({ isOpen, isClosing }) => css`
     animation: ${isOpen && !isClosing ? slideIn : slideOut} 0.3s ease-out
@@ -76,8 +77,8 @@ const DropdownFlyout = React.forwardRef<HTMLDivElement, Props>(
         isOpen={isOpen}
         isClosing={isClosing}
         flyoutMaxHeight={flyoutMaxHeight}
-        role='listbox'
-        data-testid='dropdown-flyout-test'
+        role="listbox"
+        data-testid="dropdown-flyout-test"
       >
         {children}
       </DropdownFlyoutContainer>
@@ -85,6 +86,6 @@ const DropdownFlyout = React.forwardRef<HTMLDivElement, Props>(
   }
 )
 
-DropdownFlyout.displayName = 'DropdownFlyout'
+DropdownFlyout.displayName = "DropdownFlyout"
 
 export default DropdownFlyout

--- a/src/components/Dropdown/DropdownMenu.tsx
+++ b/src/components/Dropdown/DropdownMenu.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
-import styled from '@emotion/styled'
-import Text from '../Text'
-import { ChevronIcon } from '../../assets'
-import { defaultTheme } from '../emotionTheme'
+import React from "react"
+import styled from "@emotion/styled"
+import Text from "../Text"
+import { ChevronIcon } from "../../assets"
+import { defaultTheme } from "../emotionTheme"
 
 type DropdownMenuContainerProps = {
   hasError?: boolean
@@ -10,23 +10,23 @@ type DropdownMenuContainerProps = {
   isFlyoutOpen?: boolean
 }
 
-const DropdownMenuContainer = styled('button')<DropdownMenuContainerProps>(
+const DropdownMenuContainer = styled("button")<DropdownMenuContainerProps>(
   {
-    position: 'relative',
-    margin: '0px 0px 8px 0px',
-    padding: '12px 20px 12px 20px',
-    width: '100%',
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    textAlign: 'left',
+    position: "relative",
+    margin: "0px 0px 8px 0px",
+    padding: "12px 20px 12px 20px",
+    width: "100%",
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    textAlign: "left",
     transition:
-      'box-shadow 150ms cubic-bezier(.645, .045, .355, 1), transform 150ms cubic-bezier(.645,.045,.355,1)',
-    '&:hover': {
-      transform: 'translate(-2px, -2px)',
+      "box-shadow 150ms cubic-bezier(.645, .045, .355, 1), transform 150ms cubic-bezier(.645,.045,.355,1)",
+    "&:hover": {
+      transform: "translate(-2px, -2px)",
     },
-    '&:active': {
-      transform: 'translate(-0px, -0px)',
+    "&:active": {
+      transform: "translate(-0px, -0px)",
     },
   },
   ({ theme, isFlyoutOpen, hasError, disabled }) => {
@@ -39,8 +39,8 @@ const DropdownMenuContainer = styled('button')<DropdownMenuContainerProps>(
 
     return {
       transform: !isFlyoutOpen
-        ? 'translate(-3px, -3px)'
-        : 'translate(0px, 0px)',
+        ? "translate(-3px, -3px)"
+        : "translate(0px, 0px)",
 
       background: !isFlyoutOpen
         ? theme.palette
@@ -59,15 +59,15 @@ const DropdownMenuContainer = styled('button')<DropdownMenuContainerProps>(
       borderRadius: theme.palette
         ? theme.shape.borderRadius
         : defaultTheme.shape.borderRadius,
-      boxShadow: isFlyoutOpen ? 'none' : boxShadowClosed,
-      opacity: disabled ? '50%' : 'initial',
-      cursor: !disabled ? 'pointer' : 'not-allowed',
-      '&:hover': {
+      boxShadow: isFlyoutOpen ? "none" : boxShadowClosed,
+      opacity: disabled ? "50%" : "initial",
+      cursor: !disabled ? "pointer" : "not-allowed",
+      "&:hover": {
         transform: disabled
-          ? 'translate(-3px, -3px)'
+          ? "translate(-3px, -3px)"
           : !isFlyoutOpen
-            ? 'translate(-2px, -2px)'
-            : 'translate(0px, 0px)',
+            ? "translate(-2px, -2px)"
+            : "translate(0px, 0px)",
         background: !disabled
           ? theme.palette
             ? theme.palette.primary.light
@@ -76,18 +76,18 @@ const DropdownMenuContainer = styled('button')<DropdownMenuContainerProps>(
             ? theme.palette.common.white
             : defaultTheme.palette.common.white,
         boxShadow: isFlyoutOpen
-          ? 'none'
+          ? "none"
           : !disabled
             ? boxShadowHover
-            : '3px 3px 0px 0px black',
+            : "3px 3px 0px 0px black",
       },
-      '&:active': {
+      "&:active": {
         transform: disabled
-          ? 'translate(-3px, -3px)'
+          ? "translate(-3px, -3px)"
           : !isFlyoutOpen
-            ? 'translate(0px, 0px)'
-            : 'translate(0px, 0px)',
-        boxShadow: !disabled ? 'none' : '3px 3px 0px 0px black',
+            ? "translate(0px, 0px)"
+            : "translate(0px, 0px)",
+        boxShadow: !disabled ? "none" : "3px 3px 0px 0px black",
       },
     }
   }
@@ -97,19 +97,19 @@ type IconContainerProps = {
   isOpen?: boolean
 }
 
-const IconContainer = styled('div')<IconContainerProps>(
+const IconContainer = styled("div")<IconContainerProps>(
   {
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
   },
   ({ isOpen }) => ({
-    transform: isOpen ? 'rotate(180deg)' : 'initial',
+    transform: isOpen ? "rotate(180deg)" : "initial",
   })
 )
 
 const ButtonText = styled(Text)({
-  width: '100%',
+  width: "100%",
 })
 
 type Option = {
@@ -142,6 +142,7 @@ const DropdownMenu = React.forwardRef<HTMLButtonElement, DropdownMenuProps>(
     return (
       <DropdownMenuContainer
         ref={ref}
+        type={"button"}
         isFlyoutOpen={isFlyoutOpen}
         hasError={hasError}
         disabled={disabled}
@@ -149,7 +150,7 @@ const DropdownMenu = React.forwardRef<HTMLButtonElement, DropdownMenuProps>(
         onKeyDown={onKeyDown}
       >
         <ButtonText variant="body1">
-          {value ? value.name : 'Choose an option...'}
+          {value ? value.name : "Choose an option..."}
         </ButtonText>
         <IconContainer isOpen={isFlyoutOpen}>
           <ChevronIcon />
@@ -159,6 +160,6 @@ const DropdownMenu = React.forwardRef<HTMLButtonElement, DropdownMenuProps>(
   }
 )
 
-DropdownMenu.displayName = 'DropdownMenu'
+DropdownMenu.displayName = "DropdownMenu"
 
 export default DropdownMenu


### PR DESCRIPTION
### Dropdown

**Flyout z-index**
Added a z-index to the flyout container, and it is now rendering above other form controls.

**Dropdown menu button**
If used in a form, opening the dropdown tries to submit the form and refreshes the page. Added `type={'button'}` prop to the dropdown menu container, which is a button, to prevent refreshing the page when used in a form.

Closes #273 